### PR TITLE
API ClientをpublishするためのCI

### DIFF
--- a/.github/workflows/publish_api_client.yaml
+++ b/.github/workflows/publish_api_client.yaml
@@ -1,0 +1,32 @@
+name: Publish API Client
+
+on:
+  push:
+    # branches: ["main"]
+    paths:
+      - 'packages/api_client_ts/**'
+      - '.github/workflows/publish_api_client.yaml'
+  workflow_dispatch:
+
+# Allow one concurrent deployment
+concurrency:
+  group: "api_client"
+  cancel-in-progress: true
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - uses: actions/setup-node@v1
+      with:
+        node-version: '16.x'
+        registry-url: 'https://npm.pkg.github.com'
+
+    - run: |
+        npm ci
+        npm publish
+      env:
+        NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      working-directory: 'packages/api_client_ts'

--- a/.github/workflows/publish_api_client.yaml
+++ b/.github/workflows/publish_api_client.yaml
@@ -25,6 +25,9 @@ defaults:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    permissions: 
+      contents: read
+      packages: write 
     steps:
     - uses: actions/checkout@v3
 

--- a/.github/workflows/publish_api_client.yaml
+++ b/.github/workflows/publish_api_client.yaml
@@ -2,10 +2,9 @@ name: Publish API Client
 
 on:
   push:
-    # branches: ["main"]
+    branches: ["main"]
     paths:
       - 'packages/api_client_ts/**'
-      - '.github/workflows/publish_api_client.yaml'
   workflow_dispatch:
 
 # Allow one concurrent deployment
@@ -13,21 +12,13 @@ concurrency:
   group: "api_client"
   cancel-in-progress: true
 
-# Sets permissions of the GITHUB_TOKEN to allow publishment to Github Packages
-# permissions:
-#   contents: read
-#   packages: write
-
-# defaults:
-#   run:
-#     working-directory: 'packages/api_client_ts'
+defaults:
+  run:
+    working-directory: 'packages/api_client_ts'
 
 jobs:
   publish:
     runs-on: ubuntu-latest
-    # permissions: 
-    #   contents: read
-    #   packages: write 
     steps:
     - uses: actions/checkout@v3
 
@@ -36,26 +27,11 @@ jobs:
         node-version: '16.x'
         registry-url: 'https://npm.pkg.github.com'
         scope: '@bucketfan'
-        always-auth: true
-        # token: ${{secrets.GITHUB_TOKEN}}
-
-    - run: cat /home/runner/work/_temp/.npmrc
 
     - name: Install Dependencies
       run: npm ci
-      # env:
-      #   NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      working-directory: 'packages/api_client_ts'
 
     - name: Publish to Github Packages
       run: npm publish
-      working-directory: 'packages/api_client_ts'
       env:
         NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-    - name: Archive npm failure logs
-      uses: actions/upload-artifact@v2
-      if: failure()
-      with:
-        name: npm-logs
-        path: ~/.npm/_logs

--- a/.github/workflows/publish_api_client.yaml
+++ b/.github/workflows/publish_api_client.yaml
@@ -18,9 +18,9 @@ concurrency:
 #   contents: read
 #   packages: write
 
-defaults:
-  run:
-    working-directory: 'packages/api_client_ts'
+# defaults:
+#   run:
+#     working-directory: 'packages/api_client_ts'
 
 jobs:
   publish:
@@ -45,11 +45,11 @@ jobs:
       run: npm ci
       # env:
       #   NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      # working-directory: 'packages/api_client_ts'
+      working-directory: 'packages/api_client_ts'
 
     - name: Publish to Github Packages
       run: npm publish
-      # working-directory: 'packages/api_client_ts'
+      working-directory: 'packages/api_client_ts'
       env:
         NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/publish_api_client.yaml
+++ b/.github/workflows/publish_api_client.yaml
@@ -38,6 +38,8 @@ jobs:
         scope: '@bucketfan'
         token: '${{secrets.GITHUB_TOKEN}}'
 
+    - run: cat /home/runner/work/_temp/.npmrc
+
     - name: Install Dependencies
       run: npm ci
       env:

--- a/.github/workflows/publish_api_client.yaml
+++ b/.github/workflows/publish_api_client.yaml
@@ -14,9 +14,9 @@ concurrency:
   cancel-in-progress: true
 
 # Sets permissions of the GITHUB_TOKEN to allow publishment to Github Packages
-permissions:
-  contents: read
-  packages: write
+# permissions:
+#   contents: read
+#   packages: write
 
 defaults:
   run:
@@ -25,9 +25,9 @@ defaults:
 jobs:
   publish:
     runs-on: ubuntu-latest
-    permissions: 
-      contents: read
-      packages: write 
+    # permissions: 
+    #   contents: read
+    #   packages: write 
     steps:
     - uses: actions/checkout@v3
 
@@ -43,8 +43,8 @@ jobs:
 
     - name: Install Dependencies
       run: npm ci
-      env:
-        NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # env:
+      #   NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       # working-directory: 'packages/api_client_ts'
 
     - name: Publish to Github Packages

--- a/.github/workflows/publish_api_client.yaml
+++ b/.github/workflows/publish_api_client.yaml
@@ -13,6 +13,11 @@ concurrency:
   group: "api_client"
   cancel-in-progress: true
 
+# Sets permissions of the GITHUB_TOKEN to allow publishment to Github Packages
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   publish:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish_api_client.yaml
+++ b/.github/workflows/publish_api_client.yaml
@@ -51,4 +51,4 @@ jobs:
       run: npm publish
       # working-directory: 'packages/api_client_ts'
       env:
-        NODE_AUTH_TOKEN: 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
+        NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish_api_client.yaml
+++ b/.github/workflows/publish_api_client.yaml
@@ -37,7 +37,7 @@ jobs:
         registry-url: 'https://npm.pkg.github.com'
         scope: '@bucketfan'
         always-auth: true
-        token: ${{secrets.GITHUB_TOKEN}}
+        # token: ${{secrets.GITHUB_TOKEN}}
 
     - run: cat /home/runner/work/_temp/.npmrc
 
@@ -51,4 +51,4 @@ jobs:
       run: npm publish
       # working-directory: 'packages/api_client_ts'
       env:
-        NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        NODE_AUTH_TOKEN: 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

--- a/.github/workflows/publish_api_client.yaml
+++ b/.github/workflows/publish_api_client.yaml
@@ -37,7 +37,7 @@ jobs:
         registry-url: 'https://npm.pkg.github.com'
         scope: '@bucketfan'
         always-auth: true
-        token: '${{secrets.GITHUB_TOKEN}}'
+        token: ${{secrets.GITHUB_TOKEN}}
 
     - run: cat /home/runner/work/_temp/.npmrc
 

--- a/.github/workflows/publish_api_client.yaml
+++ b/.github/workflows/publish_api_client.yaml
@@ -36,6 +36,7 @@ jobs:
         node-version: '16.x'
         registry-url: 'https://npm.pkg.github.com'
         scope: '@bucketfan'
+        always-auth: true
         token: '${{secrets.GITHUB_TOKEN}}'
 
     - run: cat /home/runner/work/_temp/.npmrc

--- a/.github/workflows/publish_api_client.yaml
+++ b/.github/workflows/publish_api_client.yaml
@@ -37,6 +37,8 @@ jobs:
 
     - name: Install Dependencies
       run: npm ci
+      env:
+        NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       # working-directory: 'packages/api_client_ts'
 
     - name: Publish to Github Packages

--- a/.github/workflows/publish_api_client.yaml
+++ b/.github/workflows/publish_api_client.yaml
@@ -52,3 +52,10 @@ jobs:
       # working-directory: 'packages/api_client_ts'
       env:
         NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Archive npm failure logs
+      uses: actions/upload-artifact@v2
+      if: failure()
+      with:
+        name: npm-logs
+        path: ~/.npm/_logs

--- a/.github/workflows/publish_api_client.yaml
+++ b/.github/workflows/publish_api_client.yaml
@@ -18,20 +18,29 @@ permissions:
   contents: read
   packages: write
 
+defaults:
+  run:
+    working-directory: 'packages/api_client_ts'
+
 jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
-    - uses: actions/setup-node@v1
+    - uses: actions/setup-node@v3
       with:
         node-version: '16.x'
         registry-url: 'https://npm.pkg.github.com'
+        scope: '@bucketfan'
+        token: '${{secrets.GITHUB_TOKEN}}'
 
-    - run: |
-        npm ci
-        npm publish
+    - name: Install Dependencies
+      run: npm ci
+      # working-directory: 'packages/api_client_ts'
+
+    - name: Publish to Github Packages
+      run: npm publish
+      # working-directory: 'packages/api_client_ts'
       env:
         NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      working-directory: 'packages/api_client_ts'

--- a/.github/workflows/publish_document.yaml
+++ b/.github/workflows/publish_document.yaml
@@ -3,6 +3,9 @@ name: Publish document to Pages
 on:
   push:
     branches: ["main"]
+    paths:
+      - 'openapi.yaml'
+      - '.github/workflows/publish_document.yaml'
   workflow_dispatch:
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages

--- a/packages/api_client_ts/package-lock.json
+++ b/packages/api_client_ts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bucketfan/radio-api-client",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@bucketfan/radio-api-client",
-      "version": "0.0.2",
+      "version": "0.0.3",
       "license": "UNLICENSED",
       "devDependencies": {
         "typescript": "^3.9.5"

--- a/packages/api_client_ts/package.json
+++ b/packages/api_client_ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bucketfan/radio-api-client",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "OpenAPI client for the Radio API",
   "author": "Bucket, Inc.",
   "license": "UNLICENSED",

--- a/packages/api_client_ts/package.json
+++ b/packages/api_client_ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bucketfan/radio-api-client",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "OpenAPI client for the Radio API",
   "author": "Bucket, Inc.",
   "license": "UNLICENSED",
@@ -12,7 +12,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/@BucketFan/Radio-Openapi.git"
+    "url": "git://github.com/@BucketFan/Radio-Openapi.git",
+    "directory": "packages/api_client_ts"
   },
   "scripts": {
     "build": "tsc",

--- a/packages/api_client_ts/package.json
+++ b/packages/api_client_ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bucketfan/radio-api-client",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "OpenAPI client for the Radio API",
   "author": "Bucket, Inc.",
   "license": "UNLICENSED",


### PR DESCRIPTION
## 変更内容
mainブランチにマージ時にapi_clientに変更があればpackageとしてpublishするように。

参考: https://docs.github.com/ja/actions/publishing-packages/publishing-nodejs-packages

## 備考
永遠に `npm ERR! 403 403 Forbidden - PUT https://npm.pkg.github.com/@bucketfan%2fradio-api-client - Permission permission_denied: write_package` で死んでたけど、
↓の設定で直った...
<img width="1184" alt="スクリーンショット 2022-11-02 19 53 56" src="https://user-images.githubusercontent.com/6408742/199473058-33d874cf-5ae0-4cd5-8ac9-53dfa0f8ebbe.png">
