### PR TITLE
api_client_tsを0.0.8にアップデート

### DIFF
--- a/packages/api_client_ts/apis/ReactionCommentsApi.ts
+++ b/packages/api_client_ts/apis/ReactionCommentsApi.ts
@@ -32,6 +32,7 @@ export interface DeleteReactionCommentsCommentIdRequest {
 export interface GetProgramReactionCommentsRequest {
     programId: string;
     order?: string;
+    cursor?: string;
 }
 
 export interface PatchReactionCommentsCommentIdRequest {
@@ -70,6 +71,7 @@ export interface ReactionCommentsApiInterface {
      * @summary Get Reactions Comment
      * @param {string} programId 
      * @param {string} [order] asc or desc
+     * @param {string} [cursor] 
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof ReactionCommentsApiInterface
@@ -80,7 +82,7 @@ export interface ReactionCommentsApiInterface {
      * 特定のプログラムのリアクションコメントを取得するAPI
      * Get Reactions Comment
      */
-    getProgramReactionComments(programId: string, order?: string, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<GetProgramReactionComments200Response>;
+    getProgramReactionComments(programId: string, order?: string, cursor?: string, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<GetProgramReactionComments200Response>;
 
     /**
      * リアクションコメントを非表示/表示にするトグルAPI。（オーナー向け）
@@ -168,6 +170,10 @@ export class ReactionCommentsApi extends runtime.BaseAPI implements ReactionComm
             queryParameters['order'] = requestParameters.order;
         }
 
+        if (requestParameters.cursor !== undefined) {
+            queryParameters['cursor'] = requestParameters.cursor;
+        }
+
         const headerParameters: runtime.HTTPHeaders = {};
 
         const response = await this.request({
@@ -184,8 +190,8 @@ export class ReactionCommentsApi extends runtime.BaseAPI implements ReactionComm
      * 特定のプログラムのリアクションコメントを取得するAPI
      * Get Reactions Comment
      */
-    async getProgramReactionComments(programId: string, order?: string, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<GetProgramReactionComments200Response> {
-        const response = await this.getProgramReactionCommentsRaw({ programId: programId, order: order }, initOverrides);
+    async getProgramReactionComments(programId: string, order?: string, cursor?: string, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<GetProgramReactionComments200Response> {
+        const response = await this.getProgramReactionCommentsRaw({ programId: programId, order: order, cursor: cursor }, initOverrides);
         return await response.value();
     }
 

--- a/packages/api_client_ts/models/CreateProgramRequest.ts
+++ b/packages/api_client_ts/models/CreateProgramRequest.ts
@@ -28,6 +28,12 @@ import {
 export interface CreateProgramRequest {
     /**
      * 
+     * @type {number}
+     * @memberof CreateProgramRequest
+     */
+    clubId?: number;
+    /**
+     * 
      * @type {string}
      * @memberof CreateProgramRequest
      */
@@ -95,6 +101,7 @@ export function CreateProgramRequestFromJSONTyped(json: any, ignoreDiscriminator
     }
     return {
         
+        'clubId': !exists(json, 'clubId') ? undefined : json['clubId'],
         'title': !exists(json, 'title') ? undefined : json['title'],
         'description': !exists(json, 'description') ? undefined : json['description'],
         'chapters': !exists(json, 'chapters') ? undefined : ((json['chapters'] as Array<any>).map(CreateProgramRequestChaptersInnerFromJSON)),
@@ -115,6 +122,7 @@ export function CreateProgramRequestToJSON(value?: CreateProgramRequest | null):
     }
     return {
         
+        'clubId': value.clubId,
         'title': value.title,
         'description': value.description,
         'chapters': value.chapters === undefined ? undefined : ((value.chapters as Array<any>).map(CreateProgramRequestChaptersInnerToJSON)),

--- a/packages/api_client_ts/models/CreateProgramRequestChaptersInner.ts
+++ b/packages/api_client_ts/models/CreateProgramRequestChaptersInner.ts
@@ -49,6 +49,12 @@ export interface CreateProgramRequestChaptersInner {
      * @memberof CreateProgramRequestChaptersInner
      */
     playTime?: number;
+    /**
+     * 
+     * @type {number}
+     * @memberof CreateProgramRequestChaptersInner
+     */
+    order?: number;
 }
 
 /**
@@ -75,6 +81,7 @@ export function CreateProgramRequestChaptersInnerFromJSONTyped(json: any, ignore
         's3Url': !exists(json, 's3Url') ? undefined : json['s3Url'],
         'contentType': !exists(json, 'contentType') ? undefined : json['contentType'],
         'playTime': !exists(json, 'playTime') ? undefined : json['playTime'],
+        'order': !exists(json, 'order') ? undefined : json['order'],
     };
 }
 
@@ -92,6 +99,7 @@ export function CreateProgramRequestChaptersInnerToJSON(value?: CreateProgramReq
         's3Url': value.s3Url,
         'contentType': value.contentType,
         'playTime': value.playTime,
+        'order': value.order,
     };
 }
 

--- a/packages/api_client_ts/models/ReactionComment.ts
+++ b/packages/api_client_ts/models/ReactionComment.ts
@@ -46,6 +46,12 @@ export interface ReactionComment {
     likedProfiles?: Array<Profile>;
     /**
      * 
+     * @type {Profile}
+     * @memberof ReactionComment
+     */
+    profile?: Profile;
+    /**
+     * 
      * @type {boolean}
      * @memberof ReactionComment
      */
@@ -91,7 +97,8 @@ export function ReactionCommentFromJSONTyped(json: any, ignoreDiscriminator: boo
         
         'id': !exists(json, 'id') ? undefined : json['id'],
         'content': !exists(json, 'content') ? undefined : json['content'],
-        'likedProfiles': !exists(json, 'LikedProfiles') ? undefined : ((json['LikedProfiles'] as Array<any>).map(ProfileFromJSON)),
+        'likedProfiles': !exists(json, 'likedProfiles') ? undefined : ((json['likedProfiles'] as Array<any>).map(ProfileFromJSON)),
+        'profile': !exists(json, 'profile') ? undefined : ProfileFromJSON(json['profile']),
         'isLiked': !exists(json, 'isLiked') ? undefined : json['isLiked'],
         'createdAt': !exists(json, 'createdAt') ? undefined : json['createdAt'],
         'updatedAt': !exists(json, 'updatedAt') ? undefined : json['updatedAt'],
@@ -110,7 +117,8 @@ export function ReactionCommentToJSON(value?: ReactionComment | null): any {
         
         'id': value.id,
         'content': value.content,
-        'LikedProfiles': value.likedProfiles === undefined ? undefined : ((value.likedProfiles as Array<any>).map(ProfileToJSON)),
+        'likedProfiles': value.likedProfiles === undefined ? undefined : ((value.likedProfiles as Array<any>).map(ProfileToJSON)),
+        'profile': ProfileToJSON(value.profile),
         'isLiked': value.isLiked,
         'createdAt': value.createdAt,
         'updatedAt': value.updatedAt,

--- a/packages/api_client_ts/package-lock.json
+++ b/packages/api_client_ts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bucketfan/radio-api-client",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@bucketfan/radio-api-client",
-      "version": "0.0.7",
+      "version": "0.0.8",
       "license": "UNLICENSED",
       "devDependencies": {
         "typescript": "4.3"

--- a/packages/api_client_ts/package.json
+++ b/packages/api_client_ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bucketfan/radio-api-client",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "OpenAPI client for the Radio API",
   "author": "Bucket, Inc.",
   "license": "UNLICENSED",

--- a/packages/api_interfaces_ts/package-lock.json
+++ b/packages/api_interfaces_ts/package-lock.json
@@ -1,5 +1,5 @@
 {
   "name": "@bucketfan/radio-api-interfaces",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "lockfileVersion": 1
 }

--- a/packages/api_interfaces_ts/package.json
+++ b/packages/api_interfaces_ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bucketfan/radio-api-interfaces",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "Interfaces for the Radio API",
   "main": "types.ts",
   "publishConfig": {

--- a/packages/api_interfaces_ts/types.ts
+++ b/packages/api_interfaces_ts/types.ts
@@ -181,7 +181,8 @@ export interface components {
     ReactionComment: {
       id?: number;
       content?: string;
-      LikedProfiles?: components["schemas"]["Profile"][];
+      likedProfiles?: components["schemas"]["Profile"][];
+      profile?: components["schemas"]["Profile"];
       isLiked?: boolean;
       createdAt?: string;
       updatedAt?: string;
@@ -278,6 +279,7 @@ export interface components {
     Program: {
       content: {
         "application/json": {
+          clubId?: number;
           title?: string;
           description?: string;
           chapters?: {
@@ -287,6 +289,7 @@ export interface components {
             /** @description mineType 例：image/jpeg */
             contentType?: string;
             playTime?: number;
+            order?: number;
           }[];
           scope?: number;
           isDraft?: boolean;
@@ -431,6 +434,7 @@ export interface operations {
       query: {
         /** asc or desc */
         order?: string;
+        cursor?: string;
       };
     };
     responses: {


### PR DESCRIPTION
## やったこと
- `npm run build:packages`でコード生成

## 確認したいこと
- `packages/api_client_ts/models/CreateProgramRequest.ts`の差分も入っていますが、
https://github.com/BucketFan/Radio-Openapi/pull/13 のPR以降`npm run build:packages`をしていなかったみたいなので含まれています。
