### PR TITLE
オーナー向けのプログラム一覧取得APIのparams修正

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -95,9 +95,9 @@ paths:
           name: cursor
           description: 次ページへのカーソル（ProgramID）
         - schema:
-            type: string
+            type: boolean
           in: query
-          name: isDraft
+          name: isOnlyDraft
           description: ONの場合、下書きのみ取得する
       tags:
         - programs


### PR DESCRIPTION
## 概要・変更内容
paramsのisDraftという名前が、テーブルのカラム名と被っていて分かりづらいので、isOnlyDraftに変更しました。

参照
https://anycloudhq.slack.com/archives/GUQKLEYCQ/p1669292129768479