### PR TITLE
chapterにplayLogをjoinさせる、query parametersのprofileIdを削除し、cursorを追加

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.2
 x-stoplight:
-  id: 35kishs1rz21q
+  id: gnxfflh1eez06
 info:
   title: radio_openapi
   version: '1.0'
@@ -243,14 +243,11 @@ paths:
       description: 特定のユーザーの再生履歴を返すAPI
       tags:
         - play_logs
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                cursor:
-                  type: string
+      parameters:
+        - schema:
+            type: string
+          in: query
+          name: cursor
   '/chapters/{id}':
     parameters:
       - schema:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.2
 x-stoplight:
-  id: nhdg0ei85qpsj
+  id: 35kishs1rz21q
 info:
   title: radio_openapi
   version: '1.0'
@@ -241,13 +241,16 @@ paths:
         '200':
           $ref: '#/components/responses/PlayLogs'
       description: 特定のユーザーの再生履歴を返すAPI
-      parameters:
-        - schema:
-            type: string
-          in: query
-          name: profileId
       tags:
         - play_logs
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                cursor:
+                  type: string
   '/chapters/{id}':
     parameters:
       - schema:
@@ -369,8 +372,8 @@ components:
           description: 固定表示ON/OFF
         mediaUrl:
           type: string
-        playTimeSeconds:
-          type: integer
+        playLog:
+          $ref: '#/components/schemas/PlayLog'
         createdAt:
           type: string
           format: date-time
@@ -387,7 +390,6 @@ components:
         - title
         - isAttachedPin
         - mediaUrl
-        - playTimeSeconds
         - createdAt
         - updatedAt
     Plan:


### PR DESCRIPTION
## やったこと
- query parametersからprofileIdを削除 // サーバーサイド側で認証するようになり、不要なので削除
- request bodyにcursorを追加 // ページネーションが必要なため

  ![Fanclove-Radio-–-Figma (1)](https://user-images.githubusercontent.com/87469023/205224762-3cce9055-5418-45a7-b9f9-e56ec97c1fa3.png)

- chapterからplayTimeSecondsを削除
- chapterにplayLogを追加 // 経過時間をchapterから取得するようにするため

## Slackでの会話

https://anycloudhq.slack.com/archives/GUQKLEYCQ/p1669949523498119