### PR TITLE
programにclubIdを追加

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -305,6 +305,8 @@ components:
       properties:
         id:
           type: integer
+        clubId:
+          type: integer
         club:
           $ref: '#/components/schemas/Club'
         title:
@@ -338,6 +340,7 @@ components:
           format: date-time
       required:
         - id
+        - clubId
         - club
         - title
         - description


### PR DESCRIPTION
## 変更概要
- programにclubIdを追加

## 変更理由
api側の実装でclubId, club両方を返すようになっており、api側でclubIdをなくすことの方が時間がかかると判断しopen apiをapi側に合わせる形に変更しました！

関連やり取り
https://anycloudhq.slack.com/archives/GUQKLEYCQ/p1670486033953359