### PR TITLE
クラブに登録されている固定プログラム一覧を取得するAPI追加

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -303,11 +303,12 @@ paths:
         required: true
     get:
       summary: Your GET endpoint
-      tags: []
+      tags:
+        - programs
       responses:
         '200':
           $ref: '#/components/responses/Programs'
-      operationId: get-programs-of_club-id-for_attached_pin
+      operationId: getProgramsOfClubIdForAttachedPin
       description: クラブに登録されている固定プログラムの一覧を取得するAPI
 components:
   schemas:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -294,6 +294,21 @@ paths:
                 example:
                   value: OK
       operationId: getHealthcheck
+  '/programs/of_club/{id}/for_attached_pin':
+    parameters:
+      - schema:
+          type: string
+        name: id
+        in: path
+        required: true
+    get:
+      summary: Your GET endpoint
+      tags: []
+      responses:
+        '200':
+          $ref: '#/components/responses/Programs'
+      operationId: get-programs-of_club-id-for_attached_pin
+      description: クラブに登録されている固定プログラムの一覧を取得するAPI
 components:
   schemas:
     Program:


### PR DESCRIPTION
## 概要・変更内容
/programs/of_club/{id}ではページネーションを行っているため、1ページ目に固定プログラムが存在しない場合があるため、固定プログラム一覧は別でAPIを作成しました。