### PR TITLE
クラブを取得するAPI追加

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -319,7 +319,8 @@ paths:
         required: true
     get:
       summary: Your GET endpoint
-      tags: []
+      tags:
+        - clubs
       responses:
         '200':
           $ref: '#/components/responses/Club'

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -310,6 +310,21 @@ paths:
           $ref: '#/components/responses/Programs'
       operationId: getProgramsOfClubIdForAttachedPin
       description: クラブに登録されている固定プログラムの一覧を取得するAPI
+  '/clubs/{id}':
+    parameters:
+      - schema:
+          type: string
+        name: id
+        in: path
+        required: true
+    get:
+      summary: Your GET endpoint
+      tags: []
+      responses:
+        '200':
+          $ref: '#/components/responses/Club'
+      operationId: getClubById
+      description: idからクラブを取得するAPI
 components:
   schemas:
     Program:
@@ -979,6 +994,19 @@ components:
                   $ref: '#/components/schemas/PlayLog'
             required:
               - playLogs
+    Club:
+      description: Example response
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              club:
+                $ref: '#/components/schemas/Club'
+        application/xml:
+          schema:
+            type: object
+            properties: {}
   requestBodies:
     Program:
       content:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -454,7 +454,7 @@ components:
           type: string
         slug:
           type: string
-        overview:
+        description:
           type: string
         icon:
           type: string
@@ -462,7 +462,7 @@ components:
           type: string
         url:
           type: string
-        programAttachedPlans:
+        plans:
           type: array
           items:
             $ref: '#/components/schemas/Plan'
@@ -482,10 +482,10 @@ components:
         - id
         - name
         - slug
-        - overview
+        - description
         - clubColor
         - url
-        - programAttachedPlans
+        - plans
     ReactionComment:
       title: ReactionComment
       x-stoplight:


### PR DESCRIPTION
## 概要・変更内容
クラブ詳細ページでクラブの情報、ラジオ登録ページで、クラブのプラン情報が必要だったので、クラブを単体で取得できるAPIを追加しました。

参照
https://anycloudhq.slack.com/archives/GUQKLEYCQ/p1670833614118809