### PR TITLE
programのbroadcastStatusとscopeの型をenumに修正

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -331,6 +331,9 @@ components:
           type: string
         broadcastStatus:
           type: integer
+          enum:
+            - ON_AIR
+            - RESERVED
         scope:
           type: integer
         chapters:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -336,6 +336,9 @@ components:
             - RESERVED
         scope:
           type: integer
+          enum:
+            - PUBLIC
+            - PRIVATE
         chapters:
           type: array
           items:


### PR DESCRIPTION
## 変更概要
- programのbroadcastStatusの型をenumに修正
- programのscopeの型をenumに修正
  - scopeも似たように指定されていたので修正しました

参考
https://github.com/BucketFan/fanclove/pull/163