### PR TITLE
ChapterのplayTimeSecondsを戻す

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.2
 x-stoplight:
-  id: gnxfflh1eez06
+  id: l35wz8tt7vcfv
 info:
   title: radio_openapi
   version: '1.0'
@@ -367,6 +367,10 @@ components:
         isAttachedPin:
           type: boolean
           description: 固定表示ON/OFF
+        playTimeSeconds:
+          type: integer
+          description: |
+            総再生時間
         mediaUrl:
           type: string
         playLog:
@@ -386,6 +390,7 @@ components:
         - order
         - title
         - isAttachedPin
+        - playTimeSeconds
         - mediaUrl
         - createdAt
         - updatedAt


### PR DESCRIPTION
## 変更内容
- https://github.com/BucketFan/Radio-Openapi/pull/39 こちらのPR時にChapterからplayTimeSecondsを削除したのですが、添付画像の部分で必要なことがわかったので、再度戻しました🙇‍♂️

## playTimeSecondsが必要な場所

- 1枚目

  ![CleanShot 2022-12-13 at 12 05 46](https://user-images.githubusercontent.com/87469023/207240148-f303a3da-0fa4-4a3a-bf6f-691fdd7653f6.png)

- 2枚目

  ![CleanShot 2022-12-13 at 12 06 11](https://user-images.githubusercontent.com/87469023/207240154-01ff1f25-900b-4269-b7f8-e9500e780e99.png)

- 3枚目

  ![CleanShot 2022-12-13 at 12 07 11@2x](https://user-images.githubusercontent.com/87469023/207240160-df91fb1a-2ec4-44db-930c-0e541f50b0ca.png)
  
  
