### PR TITLE
Programモデルに、Programを拝聴どうかを返すパラメータを追加する。

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -377,6 +377,9 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/PlayLog'
+        canYouListen:
+          type: boolean
+          description: APIを実行したアカウントがこのプログラムを聞けるかどうか。
       required:
         - id
         - clubId


### PR DESCRIPTION
マイページで、以下の画像のような、鍵マークに対応するためには、クライアント側に、Programを拝聴どうかを返すパラメータ(canYouListen:bool)の返却が必要。

オーナーであれば聞けるし、会員であれば聞ける。しかし、会員でない場合は聞けない

<img width="664" alt="スクリーンショット 2023-01-04 14 13 09" src="https://user-images.githubusercontent.com/5425553/210488839-22815c6b-138b-4332-b3d5-1191325f9d01.png">

マイページで、鍵マークが必要かどうかというのは議論が必要。
というのも、拝聴可能なプログラムだけ返せば、必要ない。
