### PR TITLE
Add get /accounts/{id}

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -327,6 +327,22 @@ paths:
             type: number
           in: query
           name: cursor
+  '/accounts/{id}':
+    parameters:
+      - schema:
+          type: string
+        name: id
+        in: path
+        required: true
+    get:
+      summary: Your GET endpoint
+      tags:
+        - accounts
+      responses:
+        '200':
+          $ref: '#/components/responses/Account'
+      operationId: getAccountsId
+      description: idからアカウント情報を取得するAPI
 components:
   schemas:
     Program:
@@ -598,6 +614,21 @@ components:
         - elapsedSeconds
         - createdAt
         - updatedAt
+    Account:
+      title: Account
+      x-stoplight:
+        id: zo7qq3x2xv08y
+      type: object
+      properties:
+        id:
+          type: number
+        plans:
+          type: array
+          items:
+            $ref: '#/components/schemas/Plan'
+      required:
+        - id
+        - plans
   responses:
     Programs:
       description: Example response
@@ -1046,6 +1077,15 @@ components:
           schema:
             type: object
             properties: {}
+    Account:
+      description: Example response
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              account:
+                $ref: '#/components/schemas/Account'
   requestBodies:
     Program:
       content:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -327,13 +327,8 @@ paths:
             type: number
           in: query
           name: cursor
-  '/accounts/{id}':
-    parameters:
-      - schema:
-          type: string
-        name: id
-        in: path
-        required: true
+  /current_account:
+    parameters: []
     get:
       summary: Your GET endpoint
       tags:
@@ -341,8 +336,8 @@ paths:
       responses:
         '200':
           $ref: '#/components/responses/Account'
-      operationId: getAccountsId
-      description: idからアカウント情報を取得するAPI
+      operationId: getCurrentAccount
+      description: ログイン中のアカウント情報を取得するAPI
 components:
   schemas:
     Program:


### PR DESCRIPTION
## 概要・変更内容
https://www.notion.so/anycloud/User-api-9d9ee09b5ad24fd4b369afcc36240546
再生できるチャプターの制御などに、アカウントが所属しているプラン情報が必要なので、アカウントの情報を取得できるAPIを追加しました。