### PR TITLE
コメントのいいねといいね取り消しのAPIを個別で用意

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -348,7 +348,7 @@ paths:
         required: true
     delete:
       summary: ''
-      operationId: CancelLikeReactionComment
+      operationId: cancelLikeReactionComment
       responses:
         '200':
           $ref: '#/components/responses/ReactionComment'

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -179,13 +179,6 @@ paths:
         $ref: '#/components/requestBodies/ReactionComment'
       tags:
         - reaction_comments
-  '/reaction_comments/like_toggle/{commentId}':
-    parameters:
-      - schema:
-          type: integer
-        name: commentId
-        in: path
-        required: true
   '/reaction_comments/{commentId}':
     parameters:
       - schema:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -339,16 +339,9 @@ paths:
       description: 特定のコメントをいいねするAPI
       tags:
         - reaction_comments
-  '/reaction_comments/cancel_like/{commentId}':
-    parameters:
-      - schema:
-          type: string
-        name: commentId
-        in: path
-        required: true
     delete:
       summary: ''
-      operationId: cancelLikeReactionComment
+      operationId: deleteReactionCommentsLike
       responses:
         '200':
           $ref: '#/components/responses/ReactionComment'

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -330,15 +330,6 @@ paths:
         name: commentId
         in: path
         required: true
-    patch:
-      summary: ''
-      operationId: likeReactionComment
-      responses:
-        '200':
-          $ref: '#/components/responses/ReactionComment'
-      description: 特定のコメントをいいねするAPI
-      tags:
-        - reaction_comments
     delete:
       summary: ''
       operationId: deleteReactionCommentsLike
@@ -346,6 +337,15 @@ paths:
         '200':
           $ref: '#/components/responses/ReactionComment'
       description: 特定のコメントのいいねを取り消すAPI
+      tags:
+        - reaction_comments
+    post:
+      summary: ''
+      operationId: likeReactionComment
+      responses:
+        '200':
+          $ref: '#/components/responses/ReactionComment'
+      description: 特定のコメントをいいねするAPI
       tags:
         - reaction_comments
 components:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -186,15 +186,6 @@ paths:
         name: commentId
         in: path
         required: true
-    patch:
-      summary: Like ON/OFF
-      operationId: patchReactionCommentsLikeToggleId
-      responses:
-        '200':
-          $ref: '#/components/responses/ReactionComment'
-      description: 指定したコメントIDをLikeをON/OFFするAPI
-      tags:
-        - reaction_comments
   '/reaction_comments/{commentId}':
     parameters:
       - schema:
@@ -339,6 +330,38 @@ paths:
           $ref: '#/components/responses/Account'
       operationId: getCurrentAccount
       description: ログイン中のアカウント情報を取得するAPI
+  '/reaction_comments/like/{commentId}':
+    parameters:
+      - schema:
+          type: string
+        name: commentId
+        in: path
+        required: true
+    patch:
+      summary: ''
+      operationId: likeReactionComment
+      responses:
+        '200':
+          $ref: '#/components/responses/ReactionComment'
+      description: 特定のコメントをいいねするAPI
+      tags:
+        - reaction_comments
+  '/reaction_comments/cancel_like/{commentId}':
+    parameters:
+      - schema:
+          type: string
+        name: commentId
+        in: path
+        required: true
+    delete:
+      summary: ''
+      operationId: CancelLikeReactionComment
+      responses:
+        '200':
+          $ref: '#/components/responses/ReactionComment'
+      description: 特定のコメントのいいねを取り消すAPI
+      tags:
+        - reaction_comments
 components:
   schemas:
     Program:


### PR DESCRIPTION
## 概要・変更内容
@KazutakaShimizu と話してapiを分ける方が良いという結論になったので、修正しました。
フロントでどちらを使うか決めてもらう方がapiの処理もシンプルで、責務的にも正しいという結論でした。