### PR TITLE
ReactionCommentのisLikedをオプショナルに

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -570,7 +570,6 @@ components:
         - content
         - likedProfiles
         - profile
-        - isLiked
         - isHidden
         - createdAt
         - updatedAt


### PR DESCRIPTION
## 概要・変更内容
ReactionCommentのisLikedはテーブルのカラムではなくなったので、APIによってはレスポンスに含まれない場合があります。
そのため、オプショナルに変更しました。