### PR TITLE
latestPlayLogUpdatedAtを削除

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -442,9 +442,6 @@ components:
         updatedAt:
           type: string
           format: date-time
-        latestPlayLogUpdatedAt:
-          type: string
-          format: date-time
       required:
         - id
         - clubId

--- a/packages/api_client_ts/models/Program.ts
+++ b/packages/api_client_ts/models/Program.ts
@@ -122,12 +122,6 @@ export interface Program {
      * @memberof Program
      */
     updatedAt: Date;
-    /**
-     * 
-     * @type {Date}
-     * @memberof Program
-     */
-    latestPlayLogUpdatedAt?: Date;
 }
 
 
@@ -186,7 +180,6 @@ export function ProgramFromJSONTyped(json: any, ignoreDiscriminator: boolean): P
         'releasedAt': !exists(json, 'releasedAt') ? undefined : (new Date(json['releasedAt'])),
         'createdAt': (new Date(json['createdAt'])),
         'updatedAt': (new Date(json['updatedAt'])),
-        'latestPlayLogUpdatedAt': !exists(json, 'latestPlayLogUpdatedAt') ? undefined : (new Date(json['latestPlayLogUpdatedAt'])),
     };
 }
 
@@ -213,7 +206,6 @@ export function ProgramToJSON(value?: Program | null): any {
         'releasedAt': value.releasedAt === undefined ? undefined : (value.releasedAt.toISOString()),
         'createdAt': (value.createdAt.toISOString()),
         'updatedAt': (value.updatedAt.toISOString()),
-        'latestPlayLogUpdatedAt': value.latestPlayLogUpdatedAt === undefined ? undefined : (value.latestPlayLogUpdatedAt.toISOString()),
     };
 }
 

--- a/packages/api_client_ts/package-lock.json
+++ b/packages/api_client_ts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bucketfan/radio-api-client",
-  "version": "0.0.41",
+  "version": "0.0.42",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@bucketfan/radio-api-client",
-      "version": "0.0.41",
+      "version": "0.0.42",
       "license": "UNLICENSED",
       "devDependencies": {
         "typescript": "4.3"

--- a/packages/api_client_ts/package.json
+++ b/packages/api_client_ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bucketfan/radio-api-client",
-  "version": "0.0.41",
+  "version": "0.0.42",
   "description": "OpenAPI client for the Radio API",
   "author": "Bucket, Inc.",
   "license": "UNLICENSED",

--- a/packages/api_interfaces_ts/package-lock.json
+++ b/packages/api_interfaces_ts/package-lock.json
@@ -1,5 +1,5 @@
 {
   "name": "@bucketfan/radio-api-interfaces",
-  "version": "0.0.40",
+  "version": "0.0.41",
   "lockfileVersion": 1
 }

--- a/packages/api_interfaces_ts/package.json
+++ b/packages/api_interfaces_ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bucketfan/radio-api-interfaces",
-  "version": "0.0.40",
+  "version": "0.0.41",
   "description": "Interfaces for the Radio API",
   "main": "types.ts",
   "publishConfig": {

--- a/packages/api_interfaces_ts/types.ts
+++ b/packages/api_interfaces_ts/types.ts
@@ -176,8 +176,6 @@ export interface components {
       createdAt: string;
       /** Format: date-time */
       updatedAt: string;
-      /** Format: date-time */
-      latestPlayLogUpdatedAt?: string;
     };
     /**
      * Chapter


### PR DESCRIPTION
関連チケット
https://www.notion.so/anycloud/API-latestPlayogUpdatedAt-c6f08ffba4574628ac25649c53df9d5a

API側の修正
https://github.com/BucketFan/Radio-Server/pull/86

フロント側の修正
https://github.com/BucketFan/Radio-Web/pull/110

レビュアー
@muraikenta @somakihiro