### PR TITLE
ProfileにisProfilePublic、publicUrlを生やす

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -642,6 +642,10 @@ components:
           type: string
         icon:
           type: string
+        isProfilePublic:
+          type: boolean
+        publicUrl:
+          type: string
       required:
         - id
         - name

--- a/packages/api_client_ts/models/Profile.ts
+++ b/packages/api_client_ts/models/Profile.ts
@@ -37,6 +37,18 @@ export interface Profile {
      * @memberof Profile
      */
     icon?: string;
+    /**
+     * 
+     * @type {boolean}
+     * @memberof Profile
+     */
+    isProfilePublic?: boolean;
+    /**
+     * 
+     * @type {string}
+     * @memberof Profile
+     */
+    publicUrl?: string;
 }
 
 /**
@@ -63,6 +75,8 @@ export function ProfileFromJSONTyped(json: any, ignoreDiscriminator: boolean): P
         'id': json['id'],
         'name': json['name'],
         'icon': !exists(json, 'icon') ? undefined : json['icon'],
+        'isProfilePublic': !exists(json, 'isProfilePublic') ? undefined : json['isProfilePublic'],
+        'publicUrl': !exists(json, 'publicUrl') ? undefined : json['publicUrl'],
     };
 }
 
@@ -78,6 +92,8 @@ export function ProfileToJSON(value?: Profile | null): any {
         'id': value.id,
         'name': value.name,
         'icon': value.icon,
+        'isProfilePublic': value.isProfilePublic,
+        'publicUrl': value.publicUrl,
     };
 }
 

--- a/packages/api_client_ts/package-lock.json
+++ b/packages/api_client_ts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bucketfan/radio-api-client",
-  "version": "0.0.47",
+  "version": "0.0.48",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@bucketfan/radio-api-client",
-      "version": "0.0.47",
+      "version": "0.0.48",
       "license": "UNLICENSED",
       "devDependencies": {
         "typescript": "4.3"

--- a/packages/api_client_ts/package.json
+++ b/packages/api_client_ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bucketfan/radio-api-client",
-  "version": "0.0.47",
+  "version": "0.0.48",
   "description": "OpenAPI client for the Radio API",
   "author": "Bucket, Inc.",
   "license": "UNLICENSED",

--- a/packages/api_interfaces_ts/package-lock.json
+++ b/packages/api_interfaces_ts/package-lock.json
@@ -1,5 +1,5 @@
 {
   "name": "@bucketfan/radio-api-interfaces",
-  "version": "0.0.46",
+  "version": "0.0.47",
   "lockfileVersion": 1
 }

--- a/packages/api_interfaces_ts/package.json
+++ b/packages/api_interfaces_ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bucketfan/radio-api-interfaces",
-  "version": "0.0.46",
+  "version": "0.0.47",
   "description": "Interfaces for the Radio API",
   "main": "types.ts",
   "publishConfig": {

--- a/packages/api_interfaces_ts/types.ts
+++ b/packages/api_interfaces_ts/types.ts
@@ -257,6 +257,8 @@ export interface components {
       id: number;
       name: string;
       icon?: string;
+      isProfilePublic?: boolean;
+      publicUrl?: string;
     };
     /** PlayLog */
     PlayLog: {


### PR DESCRIPTION
コメントのユーザーアイコンや名前をクリックした際、そのユーザーがプロフィールを公開していればプロフィールページに飛ぶようするため、GRPC側に追加されたisProfilePublic、publicUrlをopenAPIにも反映

レビュアー
@muraikenta @somakihiro @taisei1989 